### PR TITLE
feat(go): better stubbing of org/repo paths and names

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -82,11 +82,10 @@
               touch $out
             '';
         };
-      }) //
-      {
+      })
+      // {
         # nix flake new --template github:41north/templates#<template> ./new-dir
         templates = {
-
           # nix flake new --template github:41north/templates#go ./new-project
           go = {
             path = ./go;

--- a/go/README.md
+++ b/go/README.md
@@ -1,7 +1,7 @@
-# go-myapp
+# <project>
 
-![Build](https://github.com/41north/go-async/actions/workflows/ci.yml/badge.svg)
-[![Coverage Status](https://coveralls.io/repos/github/41north/go-async/badge.svg?branch=feat/readme)](https://coveralls.io/github/41north/go-async?branch=feat/readme)
+![Build](https://github.com/<org>/<repo>/actions/workflows/ci.yaml/badge.svg)
+[![Coverage Status](https://coveralls.io/repos/github/<org>/<repo>/badge.svg)](https://coveralls.io/github/<org>/<repo>)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 Status: _EXPERIMENTAL_
@@ -10,35 +10,35 @@ Status: _EXPERIMENTAL_
 
 ## Documentation
 
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/41north/go-async)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/<org>/<repo>)
 
 Full `go doc` style documentation for the project can be viewed online without
 installing this package by using the excellent GoDoc site here:
-http://godoc.org/github.com/41north/go-async
+http://godoc.org/github.com/<org>/<repo>
 
 You can also view the documentation locally once the package is installed with
 the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/41north/go-async
+http://localhost:6060/pkg/github.com/<org>/<repo>
 
 ## Installation
 
 ```bash
-$ go get -u github.com/41north/go-myproject
+$ go get -u github.com/<org>/<repo>
 ```
 
 Add this import line to the file you're working in:
 
 ```Go
-import "github.com/41north/go-myproject"
+import "github.com/<org>/<repo>"
 ```
 
 ## Quick Start
 
-**Describe here a couple of examples when using the library**
+**Describe here a couple of examples when using the project**
 
 ## License
 
-go-myproject is licensed under the [Apache 2.0 License](LICENSE)
+<project> is licensed under the [Apache 2.0 License](LICENSE)
 
 ## Contact
 

--- a/go/flake.nix
+++ b/go/flake.nix
@@ -67,6 +67,7 @@
           packages = with pkgs;
             [
               delve # https://github.com/go-delve/delve
+              gcc
               go_1_19 # https://go.dev/
               gotools # https://go.googlesource.com/tools
             ]


### PR DESCRIPTION
* fix bad badge path for ci workflow status
* stub out paths with `<org>/<repo>` instead of `41north/go-async` to make it easier to replace when instantiating
* add missing `gcc` package dependency to `flake.nix`